### PR TITLE
Raid group

### DIFF
--- a/Guild.lua
+++ b/Guild.lua
@@ -311,10 +311,26 @@ local function makeIter(key)
 		return k, v[key].note
 	end
 end
+
+local function makeIterRaidGroup(key)
+	return function (t, obj)
+		local raider = {}
+		local k,v = next(t, obj)
+		if k == nil then return nil end
+		raider.group = v.note.note
+		raider.note = v[key].note
+		return k, raider
+	end
+end
+
 function guild:GuildNotePairs()
 	return makeIter("note"), self.guild_info, nil
 end
 
 function guild:OfficerNotePairs()
 	return makeIter("officernote"), self.guild_info, nil
+end
+
+function guild:OfficerNotePairsRaidGroup(raid_group)
+	return makeIterRaidGroup("officernote"), self.guild_info, nil
 end

--- a/JitterDKP.lua
+++ b/JitterDKP.lua
@@ -519,7 +519,7 @@ function JitterDKP:DecayGuild()
 		local total = 0
 		
 		for name, group, dkp in self.dkp:dkpPairsRaidGroup() do
-			if group == self.db.profile.raid_group then 
+			if group:match(self.db.profile.raid_group) then 
 				local decay = math.floor(dkp * (self.db.profile.dkp_decay_percent * 0.01))
 				total = total + decay
 				self.dkp:SubDKP(name, decay)

--- a/JitterDKP.lua
+++ b/JitterDKP.lua
@@ -35,7 +35,7 @@ local ADDON_MSG_PREFIX = addonName
 local POPUP_NAME_I_AGREE = "JITTERDKP_I_AGREE_POPUP"
 local POPUP_NAME_YES_NO = "JITTERDKP_YES_NO_POPUP"
 
-local BOUNTY_DEFAULT = 500000
+local BOUNTY_DEFAULT = 1000000
 
 local defaults = {
 	profile = {
@@ -49,6 +49,7 @@ local defaults = {
 		decay_redistribution_percent = 100,
 		time_to_loot = 45,
 		break_ties = "random",
+		raid_group = ""
 	},
 	char = {
 		lastAnnounce = 0
@@ -494,7 +495,7 @@ function JitterDKP:DecayGuild()
 		self:printConsoleMessage("You cannot decay the guild without being in a raid")
 		return
 	end
-	self:displayYesNoAlert("Are you sure you wish to decay the guild? The amount decayed is " .. self.db.profile.dkp_decay_percent .. "%% and the amount redistributed to the raid is " .. self.db.profile.decay_redistribution_percent .. "%%.", function ()
+	self:displayYesNoAlert("Are you sure you wish to decay " .. self.db.profile.raid_group .. "? The amount decayed is " .. self.db.profile.dkp_decay_percent .. "%% and the amount redistributed to the raid is " .. self.db.profile.decay_redistribution_percent .. "%%.", function ()
 		local num_raid = GetNumGroupMembers()
 		if num_raid == 0 then
 			self:printConsoleMessage("You cannot decay the guild without being in a raid")
@@ -503,7 +504,7 @@ function JitterDKP:DecayGuild()
 		-- only redistribute dkp back to guild members
 		local members = {}
 		for i = 1, num_raid do
-			local fullname = GetRaidRosterInfo(i)
+			local fullname, rank, rankIndex, level, clss, zone, note = GetRaidRosterInfo(i)
 			words = {}
 			for word in fullname:gmatch("([^-]+)") do
 				table.insert(words,word)
@@ -517,17 +518,19 @@ function JitterDKP:DecayGuild()
 		-- don't check for 0, because the player will always be in the guild
 		local total = 0
 		
-		for name, dkp in self.dkp:dkpPairs() do
-			local decay = math.floor(dkp * (self.db.profile.dkp_decay_percent * 0.01))
-			total = total + decay
-			self.dkp:SubDKP(name, decay)
+		for name, group, dkp in self.dkp:dkpPairsRaidGroup() do
+			if group == self.db.profile.raid_group then 
+				local decay = math.floor(dkp * (self.db.profile.dkp_decay_percent * 0.01))
+				total = total + decay
+				self.dkp:SubDKP(name, decay)
+			end
 		end
 		local refund = total * (self.db.profile.decay_redistribution_percent * 0.01)
 		local perToon = math.floor(refund / #members)
 		for _,name in ipairs(members) do
 			self.dkp:AddDKP(name, perToon)
 		end
-		self:broadcastToGuild("Guild dkp has been decayed by " .. self.db.profile.dkp_decay_percent .. "%")
+		self:broadcastToGuild(self.db.profile.raid_group .. " dkp has been decayed by " .. self.db.profile.dkp_decay_percent .. "%")
 		self:broadcastToRaid(perToon .. " dkp has been awarded to " .. #members .. " players.")
 		self:printConsoleMessage((total - perToon * #members) .. " dkp has been lost to the bounty pool.")
 	end)
@@ -948,6 +951,11 @@ function JitterDKP:AceConfig3Options()
 						set = function(info, val) self.db.profile.decay_redistribution_percent = math.floor(val * 100) end,
 						order = 2,
 					},
+					raid_group = {
+						name = "Raid Group",
+						type = "input",
+						multiline = false;
+					},
 					decay = {
 						name = "Decay",
 						desc = "Decay the dkp of the guild and redistribute to the raid",
@@ -955,7 +963,7 @@ function JitterDKP:AceConfig3Options()
 						func = function (info)
 							self:DecayGuild()
 						end,
-						order = 3,
+						order = 4,
 					},
 				}
 			},

--- a/Modules/DKP.lua
+++ b/Modules/DKP.lua
@@ -113,3 +113,15 @@ function DKP:dkpPairs()
 		return k, parseOfficerNote(v)
 	end, s, var
 end
+
+-- dkpPairsRaidGroup(raid_group)
+-- Iterates over the DKP for every member with a public note matching self.db.profile.raid_group
+-- It returns 3 values: name, current dkp, lifetime dkp
+function DKP:dkpPairsRaidGroup()
+	local f, s, var = guild:OfficerNotePairsRaidGroup()
+	return function (s, var)
+		local k,v = f(s, var)
+		if k == nil then return nil end
+		return k, v.group, parseOfficerNote(v.note)
+	end, s, var
+end


### PR DESCRIPTION
Added ability to only decay based on keyword in public note. This allows multiple raid groups to use jdkp without affecting each other with decay.